### PR TITLE
Use CSV endpoint for Google Sheets and parse with CORS

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,17 +53,48 @@ function updateStore(key, values) {
   saveStores(stores);
 }
 
-function toExportUrl(url) {
-  const match = url.match(/\/d\/([a-zA-Z0-9-_]+)/);
-  if (!match) return null;
-  return `https://docs.google.com/spreadsheets/d/${match[1]}/export?format=xlsx`;
+function toExportUrl(url, gidOverride) {
+  const idMatch = url.match(/\/d\/([a-zA-Z0-9-_]+)/);
+  if (!idMatch) return null;
+  const gidMatch = url.match(/gid=([0-9]+)/);
+  const gid = gidOverride || (gidMatch ? gidMatch[1] : '0');
+  return `https://docs.google.com/spreadsheets/d/${idMatch[1]}/gviz/tq?tqx=out:csv&gid=${gid}`;
 }
 
-async function fetchWorkbook(url) {
-  const exportUrl = toExportUrl(url);
+async function fetchWorkbook(url, gidOverride) {
+  const exportUrl = toExportUrl(url, gidOverride);
   const res = await fetch(exportUrl);
-  const buf = await res.arrayBuffer();
-  return XLSX.read(buf, { type: 'array' });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  const csv = await res.text();
+  const wb = XLSX.read(csv, { type: 'string' });
+  const sheetName = wb.SheetNames[0];
+  const data = XLSX.utils.sheet_to_json(wb.Sheets[sheetName], { header: 1, blankrows: false });
+  return { sheetName, data };
+}
+
+async function fetchSheetList(url) {
+  const idMatch = url.match(/\/d\/([a-zA-Z0-9-_]+)/);
+  if (!idMatch) return [];
+  const res = await fetch(`https://spreadsheets.google.com/feeds/worksheets/${idMatch[1]}/public/basic?alt=json`);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  const json = await res.json();
+  return (json.feed.entry || []).map(entry => {
+    const name = entry.title.$t;
+    const link = entry.link && entry.link.find(l => l.rel === 'alternate');
+    let gid = null;
+    if (link) {
+      try {
+        gid = new URL(link.href).searchParams.get('gid');
+      } catch (e) {
+        gid = null;
+      }
+    }
+    return { name, gid };
+  });
 }
 
 function calculatePayroll(data, baseWage, overtime) {

--- a/payroll.js
+++ b/payroll.js
@@ -2,13 +2,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('version').textContent = `ver.${APP_VERSION}`;
   const params = new URLSearchParams(location.search);
   const storeKey = params.get('store');
-  const sheetName = params.get('sheet');
+  const gid = params.get('gid');
   const store = getStore(storeKey);
   if (!store) return;
   try {
-    const wb = await fetchWorkbook(store.url);
-    const ws = wb.Sheets[sheetName];
-    const data = XLSX.utils.sheet_to_json(ws, { header: 1, blankrows: false });
+    const { data } = await fetchWorkbook(store.url, gid);
     const year = data[1] && data[1][0];
     const startMonth = data[3] && data[3][14];
     const endMonth = ('0' + (((parseInt(startMonth, 10) || 0) % 12) + 1)).slice(-2);

--- a/sheets.js
+++ b/sheets.js
@@ -5,13 +5,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   const store = getStore(storeKey);
   if (!store) return;
   try {
-    const wb = await fetchWorkbook(store.url);
+    const sheets = await fetchSheetList(store.url);
     const list = document.getElementById('sheet-list');
-    wb.SheetNames.forEach(name => {
+    sheets.forEach(({ name, gid }) => {
       const btn = document.createElement('button');
       btn.textContent = name;
       btn.addEventListener('click', () => {
-        window.location.href = `payroll.html?store=${storeKey}&sheet=${encodeURIComponent(name)}`;
+        window.location.href = `payroll.html?store=${storeKey}&gid=${gid}`;
       });
       list.appendChild(btn);
     });


### PR DESCRIPTION
## Summary
- Replace `export?format=xlsx` with the CORS-friendly gviz CSV endpoint
- Parse CSV in `fetchWorkbook`, report HTTP failures, and expose sheet list
- Update sheet selection and payroll parsing to consume CSV data via `gid`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9c279d90832db2d539b2152be377