### PR TITLE
Add helper for Google Sheets file ID and XLSX export URL

### DIFF
--- a/payroll.js
+++ b/payroll.js
@@ -2,13 +2,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('version').textContent = `ver.${APP_VERSION}`;
   const params = new URLSearchParams(location.search);
   const storeKey = params.get('store');
-  const sheetName = params.get('sheet');
+  const sheetIndex = parseInt(params.get('sheet'), 10) || 0;
   const store = getStore(storeKey);
   if (!store) return;
   try {
-    const wb = await fetchWorkbook(store.url);
-    const ws = wb.Sheets[sheetName];
-    const data = XLSX.utils.sheet_to_json(ws, { header: 1, blankrows: false });
+    const { data } = await fetchWorkbook(store.url, sheetIndex);
     const year = data[1] && data[1][0];
     const startMonth = data[3] && data[3][14];
     const endMonth = ('0' + (((parseInt(startMonth, 10) || 0) % 12) + 1)).slice(-2);

--- a/sheets.js
+++ b/sheets.js
@@ -5,13 +5,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   const store = getStore(storeKey);
   if (!store) return;
   try {
-    const wb = await fetchWorkbook(store.url);
+    const sheets = await fetchSheetList(store.url);
     const list = document.getElementById('sheet-list');
-    wb.SheetNames.forEach(name => {
+    sheets.forEach(({ name, index }) => {
       const btn = document.createElement('button');
       btn.textContent = name;
       btn.addEventListener('click', () => {
-        window.location.href = `payroll.html?store=${storeKey}&sheet=${encodeURIComponent(name)}`;
+        window.location.href = `payroll.html?store=${storeKey}&sheet=${index}`;
       });
       list.appendChild(btn);
     });


### PR DESCRIPTION
## Summary
- replace deprecated worksheet feed with XLSX export and parse sheet names by index
- download sheet data via XLSX export using sheet index
- update sheet navigation to pass sheet index instead of gid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9c279d90832db2d539b2152be377