### PR TITLE
Adjust layout and navigation

### DIFF
--- a/payroll.html
+++ b/payroll.html
@@ -11,11 +11,11 @@
 </head>
 <body>
   <header>
-    <button class="back-btn" onclick="history.back()">&lt;</button>
-    <span id="version"></span>
+    <span></span>
+    <a href="index.html" class="home-btn">トップページ</a>
   </header>
-  <h1 id="period" style="text-align:center"></h1>
-  <h2 id="store-name" style="text-align:center"></h2>
+  <h1 id="store-name" style="text-align:center"></h1>
+  <h2 id="period" style="text-align:center"></h2>
   <p id="total-salary" style="text-align:center"></p>
   <table id="employees">
     <thead>

--- a/payroll.js
+++ b/payroll.js
@@ -1,5 +1,4 @@
 document.addEventListener('DOMContentLoaded', async () => {
-  document.getElementById('version').textContent = `ver.${APP_VERSION}`;
   const params = new URLSearchParams(location.search);
   const storeKey = params.get('store');
 

--- a/settings.html
+++ b/settings.html
@@ -11,8 +11,8 @@
 </head>
 <body>
   <header>
-    <button class="back-btn" onclick="history.back()">&lt;</button>
-    <span id="version"></span>
+    <span></span>
+    <a href="index.html" class="home-btn">トップページ</a>
   </header>
   <h1 style="text-align:center">設定</h1>
   <div style="padding:1rem;">

--- a/settings.js
+++ b/settings.js
@@ -1,5 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('version').textContent = `ver.${APP_VERSION}`;
   const select = document.getElementById('store-select');
   const stores = loadStores();
   Object.keys(DEFAULT_STORES).forEach(key => {

--- a/sheets.html
+++ b/sheets.html
@@ -11,10 +11,10 @@
 </head>
 <body>
   <header>
-    <button class="back-btn" onclick="history.back()">&lt;</button>
-    <span id="version"></span>
+    <span></span>
+    <a href="index.html" class="home-btn">トップページ</a>
   </header>
-  <h1 style="text-align:center">計算する月を選択してください。</h1>
+  <h1 style="text-align:center">計算する月を選択</h1>
   <div id="sheet-list"></div>
 </body>
 </html>

--- a/sheets.js
+++ b/sheets.js
@@ -1,5 +1,4 @@
 document.addEventListener('DOMContentLoaded', async () => {
-  document.getElementById('version').textContent = `ver.${APP_VERSION}`;
   const params = new URLSearchParams(location.search);
   const storeKey = params.get('store');
   const store = getStore(storeKey);

--- a/style.css
+++ b/style.css
@@ -10,10 +10,11 @@ header {
   padding: 0.5rem 1rem;
   background: #f0f0f0;
 }
-.back-btn {
+.home-btn {
   font-size: 1.2rem;
   background: none;
   border: none;
+  text-decoration: none;
 }
 #store-list button, #sheet-list button {
   display: block;


### PR DESCRIPTION
## Summary
- Show version only on top page and add a Home link on other pages.
- Rename month selection heading and adjust payroll heading hierarchy.
- Introduce reusable `home-btn` styling.

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1ad0a434832d8b8df3e277fd7be7