### PR TITLE
Add loading indicators to payroll workflow

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,6 +53,16 @@ function updateStore(key, values) {
   saveStores(stores);
 }
 
+function startLoading(el, text) {
+  if (!el) return;
+  el.textContent = text;
+}
+
+function stopLoading(el) {
+  if (!el) return;
+  el.textContent = '';
+}
+
 
 function extractFileId(url) {
   const match = url.match(/\/d\/([a-zA-Z0-9_-]+)(?:\/|$)/);

--- a/payroll.html
+++ b/payroll.html
@@ -17,6 +17,7 @@
   </header>
   <h1 id="store-name" style="text-align:center"></h1>
   <h2 id="period" style="text-align:center"></h2>
+  <p id="status" style="text-align:center"></p>
   <p id="total-salary" style="text-align:center"></p>
   <table id="employees">
     <thead>

--- a/payroll.js
+++ b/payroll.js
@@ -5,9 +5,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   const sheetIndex = parseInt(params.get('sheet'), 10) || 0;
   const store = getStore(storeKey);
   if (!store) return;
+  const statusEl = document.getElementById('status');
+  startLoading(statusEl, '読込中');
   try {
     const { data } = await fetchWorkbook(store.url, sheetIndex);
-
+    stopLoading(statusEl);
     const year = data[1] && data[1][0];
     const startMonth = data[3] && data[3][14];
     const endMonth = ('0' + (((parseInt(startMonth, 10) || 0) % 12) + 1)).slice(-2);
@@ -15,6 +17,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const nameRow = data[36] || [];
     const storeName = nameRow.slice(14, 25).find(v => v) || store.name;
     document.getElementById('store-name').textContent = storeName;
+    startLoading(statusEl, '計算中');
 
     const { results, totalSalary } = calculatePayroll(data, store.baseWage, store.overtime);
     document.getElementById('total-salary').textContent = `合計支払い給与：${totalSalary.toLocaleString()}円`;
@@ -25,9 +28,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       tr.addEventListener('click', () => alert('日毎の勤務時間表示は未実装です'));
       tbody.appendChild(tr);
     });
+    stopLoading(statusEl);
 
     document.getElementById('download').addEventListener('click', () => downloadResults(storeName, `${year}${startMonth}`, store, results));
   } catch (e) {
+    stopLoading(statusEl);
     document.getElementById('error').textContent = 'URLが変更された可能性があります。設定からURL変更をお試しください。';
   }
 });


### PR DESCRIPTION
## Summary
- Show a `status` message area above totals
- Display loading indicators during data fetch and payroll calculation
- Stop loaders and report errors in `#error`

## Testing
- ⚠️ `npm test` *(missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad20b61858832db6e9ff2c4ae007b8