### PR TITLE
Show loading indicators and unify navigation icons

### DIFF
--- a/payroll.html
+++ b/payroll.html
@@ -13,7 +13,7 @@
   <header>
     <button class="back-btn" onclick="history.back()">&lt;</button>
 
-    <a href="index.html" class="home-btn">トップページ</a>
+    <button class="back-btn" onclick="location.href='index.html'">↺</button>
   </header>
   <h1 id="store-name" style="text-align:center"></h1>
   <h2 id="period" style="text-align:center"></h2>

--- a/payroll.js
+++ b/payroll.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const store = getStore(storeKey);
   if (!store) return;
   const statusEl = document.getElementById('status');
-  startLoading(statusEl, '読込中');
+  startLoading(statusEl, '読込中・・・');
   try {
     const { data } = await fetchWorkbook(store.url, sheetIndex);
     stopLoading(statusEl);
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const nameRow = data[36] || [];
     const storeName = nameRow.slice(14, 25).find(v => v) || store.name;
     document.getElementById('store-name').textContent = storeName;
-    startLoading(statusEl, '計算中');
+    startLoading(statusEl, '計算中・・・');
 
     const { results, totalSalary } = calculatePayroll(data, store.baseWage, store.overtime);
     document.getElementById('total-salary').textContent = `合計支払い給与：${totalSalary.toLocaleString()}円`;

--- a/settings.html
+++ b/settings.html
@@ -14,7 +14,7 @@
 
     <button class="back-btn" onclick="history.back()">&lt;</button>
 
-    <a href="index.html" class="home-btn">トップページ</a>
+    <button class="back-btn" onclick="location.href='index.html'">↺</button>
   </header>
   <h1 style="text-align:center">設定</h1>
   <div style="padding:1rem;">

--- a/sheets.html
+++ b/sheets.html
@@ -13,9 +13,10 @@
   <header>
     <button class="back-btn" onclick="history.back()">&lt;</button>
 
-    <a href="index.html" class="home-btn">トップページ</a>
+    <button class="back-btn" onclick="location.href='index.html'">↺</button>
   </header>
   <h1 style="text-align:center">計算する月を選択</h1>
+  <p id="status" style="text-align:center"></p>
   <div id="sheet-list"></div>
 </body>
 </html>

--- a/sheets.js
+++ b/sheets.js
@@ -3,8 +3,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   const storeKey = params.get('store');
   const store = getStore(storeKey);
   if (!store) return;
+  const statusEl = document.getElementById('status');
+  startLoading(statusEl, '読込中・・・');
   try {
     const sheets = await fetchSheetList(store.url);
+    stopLoading(statusEl);
     const list = document.getElementById('sheet-list');
 
     sheets.forEach(({ name, index }) => {
@@ -17,6 +20,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       list.appendChild(btn);
     });
   } catch (e) {
+    stopLoading(statusEl);
     document.getElementById('sheet-list').textContent = 'URLが変更された可能性があります。設定からURL変更をお試しください。';
   }
 });

--- a/style.css
+++ b/style.css
@@ -10,19 +10,6 @@ header {
   padding: 0.5rem 1rem;
   background: #f0f0f0;
 }
-.home-btn {
-  font-size: 1.2rem;
-  background: none;
-  border: none;
-  text-decoration: none;
-}
-
-.home-btn {
-  font-size: 1.2rem;
-  background: none;
-  border: none;
-  text-decoration: none;
-}
 #store-list button, #sheet-list button {
   display: block;
   width: 90%;


### PR DESCRIPTION
## Summary
- Display `読込中・・・` while loading shift sheets and `計算中・・・` during payroll calculations
- Replace "トップページ" links with `↺` buttons styled like back buttons
- Remove unused home button styling and add sheet loading status element

## Testing
- `node --check payroll.js`
- `node --check sheets.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad240bf028832db0ea47dd1115bc4e