### PR TITLE
Format sheet names into date ranges

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,6 +102,20 @@ async function fetchSheetList(url) {
 
 }
 
+function formatSheetName(name) {
+  const m = name.match(/^(?:(\d{1,2})\.)?(\d{3,4})-(\d{3,4})$/);
+  if (!m) return name;
+  const parseMD = str => {
+    const month = parseInt(str.slice(0, -2), 10);
+    const day = parseInt(str.slice(-2), 10);
+    return { month, day };
+  };
+  const start = parseMD(m[2]);
+  const end = parseMD(m[3]);
+  const year = m[1] ? `20${m[1]}年` : '';
+  return `${year}${start.month}月${start.day}日～${end.month}月${end.day}日`;
+}
+
 function calculatePayroll(data, baseWage, overtime) {
   const header = data[2];
   const names = [];

--- a/sheets.js
+++ b/sheets.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     sheets.forEach(({ name, index }) => {
       const btn = document.createElement('button');
-      btn.textContent = name;
+      btn.textContent = formatSheetName(name);
       btn.addEventListener('click', () => {
         window.location.href = `payroll.html?store=${storeKey}&sheet=${index}`;
 


### PR DESCRIPTION
## Summary
- convert sheet name patterns like `25.816-915` into `2025年8月16日～9月15日`
- display converted date ranges on sheet selection page

## Testing
- `node -e "const fs=require('fs');const code=fs.readFileSync('./app.js','utf8');eval(code);console.log(formatSheetName('25.816-915'));console.log(formatSheetName('816-915'));console.log(formatSheetName('abc'));"`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad27d23dfc832d8527a9361e1565f6