### PR TITLE
Set default wage to 1225 and manage exclusion words

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,38 +4,47 @@ const DEFAULT_STORES = {
   night: {
     name: '夜勤',
     url: 'https://docs.google.com/spreadsheets/d/1gCGyxiXXxOOhgHG2tk3BlzMpXuaWQULacySlIhhoWRY/edit?gid=601593061#gid=601593061',
-    baseWage: 1000,
-    overtime: 1.25
+    baseWage: 1225,
+    overtime: 1.25,
+    excludeWords: ['月', '日', '曜日', '空き', '予定', '.']
   },
   sagamihara_higashi: {
     name: '相模原東大沼店',
     url: 'https://docs.google.com/spreadsheets/d/1fEMEasqSGU30DuvCx6O6D0nJ5j6m6WrMkGTAaSQuqBY/edit?gid=358413717#gid=358413717',
-    baseWage: 1000,
-    overtime: 1.25
+    baseWage: 1225,
+    overtime: 1.25,
+    excludeWords: ['月', '日', '曜日', '空き', '予定', '.']
   },
   kobuchi: {
     name: '古淵駅前店',
     url: 'https://docs.google.com/spreadsheets/d/1hSD3sdIQftusWcNegZnGbCtJmByZhzpAvLJegDoJckQ/edit?gid=946573079#gid=946573079',
-    baseWage: 1000,
-    overtime: 1.25
+    baseWage: 1225,
+    overtime: 1.25,
+    excludeWords: ['月', '日', '曜日', '空き', '予定', '.']
   },
   hashimoto: {
     name: '相模原橋本五丁目店',
     url: 'https://docs.google.com/spreadsheets/d/1YYvWZaF9Li_RHDLevvOm2ND8ASJ3864uHRkDAiWBEDc/edit?gid=2000770170#gid=2000770170',
-    baseWage: 1000,
-    overtime: 1.25
+    baseWage: 1225,
+    overtime: 1.25,
+    excludeWords: ['月', '日', '曜日', '空き', '予定', '.']
   },
   isehara: {
     name: '伊勢原高森七丁目店',
     url: 'https://docs.google.com/spreadsheets/d/1PfEQRnvHcKS5hJ6gkpJQc0VFjDoJUBhHl7JTTyJheZc/edit?gid=34390331#gid=34390331',
-    baseWage: 1000,
-    overtime: 1.25
+    baseWage: 1225,
+    overtime: 1.25,
+    excludeWords: ['月', '日', '曜日', '空き', '予定', '.']
   }
 };
 
 function loadStores() {
   const stored = JSON.parse(localStorage.getItem('stores') || '{}');
-  return { ...DEFAULT_STORES, ...stored };
+  const merged = { ...stored };
+  Object.keys(DEFAULT_STORES).forEach(key => {
+    merged[key] = { ...DEFAULT_STORES[key], ...(stored[key] || {}) };
+  });
+  return merged;
 }
 
 function saveStores(stores) {
@@ -102,13 +111,13 @@ async function fetchSheetList(url) {
 
 }
 
-function calculatePayroll(data, baseWage, overtime) {
+function calculatePayroll(data, baseWage, overtime, excludeWords = []) {
   const header = data[2];
   const names = [];
   const schedules = [];
   for (let col = 3; col < header.length; col++) {
     const name = header[col];
-    if (name && !['月', '日', '曜日', '空き', '予定', '.'].includes(name)) {
+    if (name && !excludeWords.some(word => name.includes(word))) {
       names.push(name);
       schedules.push(data.slice(3).map(row => row[col]));
     }

--- a/payroll.js
+++ b/payroll.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('store-name').textContent = storeName;
     startLoading(statusEl, '計算中・・・');
 
-    const { results, totalSalary } = calculatePayroll(data, store.baseWage, store.overtime);
+    const { results, totalSalary } = calculatePayroll(data, store.baseWage, store.overtime, store.excludeWords || []);
     document.getElementById('total-salary').textContent = `合計支払い給与：${totalSalary.toLocaleString()}円`;
     const tbody = document.querySelector('#employees tbody');
     results.forEach(r => {

--- a/settings.html
+++ b/settings.html
@@ -22,6 +22,7 @@
     <label>シートURL<input id="url" style="width:100%"></label><br><br>
     <label>基本時給<input id="baseWage" type="number"></label><br><br>
     <label>時間外倍率<input id="overtime" type="number" step="0.01"></label><br><br>
+    <label>従業員名除外ワード<input id="excludeWords" style="width:100%" placeholder="カンマ区切りで入力"></label><br><br>
     <button id="save">保存</button>
     <button id="reset">デフォルトに戻す</button>
   </div>

--- a/settings.js
+++ b/settings.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('url').value = store.url;
     document.getElementById('baseWage').value = store.baseWage;
     document.getElementById('overtime').value = store.overtime;
+    document.getElementById('excludeWords').value = (store.excludeWords || []).join(',');
   }
 
   select.addEventListener('change', () => load(select.value));
@@ -23,7 +24,8 @@ document.addEventListener('DOMContentLoaded', () => {
     updateStore(select.value, {
       url: document.getElementById('url').value,
       baseWage: parseFloat(document.getElementById('baseWage').value),
-      overtime: parseFloat(document.getElementById('overtime').value)
+      overtime: parseFloat(document.getElementById('overtime').value),
+      excludeWords: document.getElementById('excludeWords').value.split(',').map(s => s.trim()).filter(s => s)
     });
     alert('保存しました');
   });


### PR DESCRIPTION
## Summary
- update default hourly wage to 1225 yen for all stores
- allow managing comma-separated employee name exclusion words in settings and apply them to payroll

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js settings.js payroll.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad37828df0832d96c533816c1bb364