### PR TITLE
Display store name above month selection

### DIFF
--- a/sheets.html
+++ b/sheets.html
@@ -15,7 +15,8 @@
 
     <button class="back-btn" onclick="location.href='index.html'">↺</button>
   </header>
-  <h1 style="text-align:center">計算する月を選択</h1>
+  <h1 id="store-name" style="text-align:center"></h1>
+  <h2 style="text-align:center">計算する月を選択</h2>
   <p id="status" style="text-align:center"></p>
   <div id="sheet-list"></div>
 </body>

--- a/sheets.js
+++ b/sheets.js
@@ -17,6 +17,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const storeKey = params.get('store');
   const store = getStore(storeKey);
   if (!store) return;
+  document.getElementById('store-name').textContent = store.name;
   const statusEl = document.getElementById('status');
   startLoading(statusEl, '読込中・・・');
   try {


### PR DESCRIPTION
## Summary
- Add a dedicated heading placeholder on the sheets page and populate it with the selected store name
- Keep a second heading prompting users to select the month for payroll calculations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad418b0038832d879f9db263ae12f9