### PR TITLE
Validate wage settings and allow per-employee recalculation

### DIFF
--- a/payroll.html
+++ b/payroll.html
@@ -25,6 +25,7 @@
     </thead>
     <tbody></tbody>
   </table>
+  <button id="recalc">再計算</button>
   <button id="download">CSVダウンロード</button>
   <p id="error" style="color:red;text-align:center"></p>
 </body>

--- a/payroll.js
+++ b/payroll.js
@@ -19,26 +19,45 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('store-name').textContent = storeName;
     startLoading(statusEl, '計算中・・・');
 
-    const { results, totalSalary } = calculatePayroll(data, store.baseWage, store.overtime, store.excludeWords || []);
+    const { results, totalSalary, schedules } = calculatePayroll(data, store.baseWage, store.overtime, store.excludeWords || []);
     document.getElementById('total-salary').textContent = `合計支払い給与：${totalSalary.toLocaleString()}円`;
     const tbody = document.querySelector('#employees tbody');
-    results.forEach(r => {
+    results.forEach((r, idx) => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${r.name}</td><td>${store.baseWage}</td><td>${r.hours.toFixed(2)}</td><td>${r.days}</td><td>${r.salary.toLocaleString()}</td>`;
+      tr.innerHTML = `<td>${r.name}</td><td><input type="number" value="${r.baseWage}" class="wage-input" data-idx="${idx}"></td><td>${r.hours.toFixed(2)}</td><td>${r.days}</td><td class="salary-cell">${r.salary.toLocaleString()}</td>`;
       tr.addEventListener('click', () => alert('日毎の勤務時間表示は未実装です'));
       tbody.appendChild(tr);
     });
     stopLoading(statusEl);
 
-    document.getElementById('download').addEventListener('click', () => downloadResults(storeName, `${year}${startMonth}`, store, results));
+    document.getElementById('recalc').addEventListener('click', () => {
+      const inputs = document.querySelectorAll('.wage-input');
+      let total = 0;
+      inputs.forEach(input => {
+        const idx = parseInt(input.dataset.idx, 10);
+        const wage = Number(input.value);
+        if (!Number.isFinite(wage)) {
+          total += results[idx].salary;
+          return;
+        }
+        const r = calculateEmployee(schedules[idx], wage, store.overtime);
+        results[idx].baseWage = wage;
+        results[idx].salary = r.salary;
+        total += r.salary;
+        input.closest('tr').querySelector('.salary-cell').textContent = r.salary.toLocaleString();
+      });
+      document.getElementById('total-salary').textContent = `合計支払い給与：${total.toLocaleString()}円`;
+    });
+
+    document.getElementById('download').addEventListener('click', () => downloadResults(storeName, `${year}${startMonth}`, results));
   } catch (e) {
     stopLoading(statusEl);
     document.getElementById('error').textContent = 'URLが変更された可能性があります。設定からURL変更をお試しください。';
   }
 });
 
-function downloadResults(storeName, period, store, results) {
-  const aoa = [['従業員名', '基本時給', '勤務時間', '出勤日数', '給与'], ...results.map(r => [r.name, store.baseWage, r.hours, r.days, r.salary])];
+function downloadResults(storeName, period, results) {
+  const aoa = [['従業員名', '基本時給', '勤務時間', '出勤日数', '給与'], ...results.map(r => [r.name, r.baseWage, r.hours, r.days, r.salary])];
   const ws = XLSX.utils.aoa_to_sheet(aoa);
   const wb = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(wb, ws, '結果');

--- a/settings.js
+++ b/settings.js
@@ -10,10 +10,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function load(key) {
     const store = getStore(key);
+    const def = DEFAULT_STORES[key];
     document.getElementById('url').value = store.url;
-    document.getElementById('baseWage').value = store.baseWage;
-    document.getElementById('overtime').value = store.overtime;
-    document.getElementById('excludeWords').value = (store.excludeWords || []).join(',');
+    document.getElementById('baseWage').value = Number.isFinite(store.baseWage) ? store.baseWage : def.baseWage;
+    document.getElementById('overtime').value = Number.isFinite(store.overtime) ? store.overtime : def.overtime;
+    const words = Array.isArray(store.excludeWords) ? store.excludeWords : def.excludeWords;
+    document.getElementById('excludeWords').value = (words || []).join(',');
   }
 
   select.addEventListener('change', () => load(select.value));
@@ -21,10 +23,16 @@ document.addEventListener('DOMContentLoaded', () => {
   load(select.value);
 
   document.getElementById('save').addEventListener('click', () => {
+    const baseWage = Number(document.getElementById('baseWage').value);
+    const overtime = Number(document.getElementById('overtime').value);
+    if (!Number.isFinite(baseWage) || !Number.isFinite(overtime)) {
+      alert('数値を入力してください');
+      return;
+    }
     updateStore(select.value, {
       url: document.getElementById('url').value,
-      baseWage: parseFloat(document.getElementById('baseWage').value),
-      overtime: parseFloat(document.getElementById('overtime').value),
+      baseWage,
+      overtime,
       excludeWords: document.getElementById('excludeWords').value.split(',').map(s => s.trim()).filter(s => s)
     });
     alert('保存しました');


### PR DESCRIPTION
## Summary
- Validate wage input in settings and fall back to defaults when data is invalid
- Harden store loading from localStorage with JSON and numeric checks
- Allow editing wages per employee and recalculate total salary

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4e8470f0832d89ef2a36ec519f46