### PR TITLE
Improve navigation labels and version 1.0.1 updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-const APP_VERSION = '1.0.0';
+const APP_VERSION = '1.0.1';
 
 const DEFAULT_STORES = {
   night: {

--- a/index.html
+++ b/index.html
@@ -12,9 +12,17 @@
 <body>
   <header>
     <span id="version"></span>
-    <a href="settings.html" id="settings">⚙</a>
+    <button class="back-btn" id="settings" onclick="location.href='settings.html'">設定</button>
   </header>
   <h1 style="text-align:center">簡易給与計算</h1>
   <div id="store-list"></div>
+  <div class="info-box">
+    <div style="text-align:center;font-size:1.2rem;">●お知らせ●</div>
+    <div>
+      ver.1.0.1<br>
+      各ボタンをわかりやすく調整しました。<br>
+      エラーメッセージをわかりやすく調整しました。
+    </div>
+  </div>
 </body>
 </html>

--- a/payroll.html
+++ b/payroll.html
@@ -11,9 +11,8 @@
 </head>
 <body>
   <header>
-    <button class="back-btn" onclick="history.back()">&lt;</button>
-
-    <button class="back-btn" onclick="location.href='index.html'">↺</button>
+    <button class="back-btn" onclick="history.back()">&lt;月選択</button>
+    <button class="back-btn" onclick="location.href='index.html'">はじめから↺</button>
   </header>
   <h1 id="store-name" style="text-align:center"></h1>
   <h2 id="period" style="text-align:center"></h2>

--- a/payroll.js
+++ b/payroll.js
@@ -104,7 +104,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('download').addEventListener('click', () => downloadResults(storeName, `${year}${startMonthRaw}`, results));
   } catch (e) {
     stopLoading(statusEl);
-    document.getElementById('error').textContent = 'URLが変更された可能性があります。設定からURL変更をお試しください。';
+    document.getElementById('error').innerHTML = 'スプレッドシートを読み込めませんでした。<br>通信状況が悪いか、URLが変更された可能性があります。<br>店舗選択画面の設定からURL変更をお試しください。';
   }
 });
 

--- a/settings.html
+++ b/settings.html
@@ -11,10 +11,8 @@
 </head>
 <body>
   <header>
-
-    <button class="back-btn" onclick="history.back()">&lt;</button>
-
-    <button class="back-btn" onclick="location.href='index.html'">↺</button>
+    <button class="back-btn" onclick="history.back()">&lt;トップ</button>
+    <button class="back-btn" onclick="location.href='index.html'">はじめから↺</button>
   </header>
   <h1 style="text-align:center">設定</h1>
   <div style="padding:1rem;">
@@ -25,6 +23,10 @@
     <label>従業員名除外ワード<input id="excludeWords" style="width:100%" placeholder="カンマ区切りで入力"></label><br><br>
     <button id="save">保存</button>
     <button id="reset">デフォルトに戻す</button>
+    <div class="info-box" style="margin-top:1rem;">
+      シートのURLが変更された場合、変更したい店舗名を選択し、シートURLに変更後のURLを入力してください。<br>
+      従業員名除外ワードには意図しない従業員名が表示された際にカンマ区切り( , )で追加してください。
+    </div>
   </div>
 </body>
 </html>

--- a/sheets.html
+++ b/sheets.html
@@ -11,9 +11,8 @@
 </head>
 <body>
   <header>
-    <button class="back-btn" onclick="history.back()">&lt;</button>
-
-    <button class="back-btn" onclick="location.href='index.html'">↺</button>
+    <button class="back-btn" onclick="history.back()">&lt;店舗選択</button>
+    <button class="back-btn" onclick="location.href='index.html'">はじめから↺</button>
   </header>
   <h1 id="store-name" style="text-align:center"></h1>
   <h2 style="text-align:center">計算する月を選択</h2>

--- a/style.css
+++ b/style.css
@@ -50,3 +50,15 @@ th, td {
 .wage-input {
   width: 4rem;
 }
+
+.back-btn {
+  padding: 0.25rem 0.5rem;
+  font-size: 1rem;
+}
+
+.info-box {
+  border: 1px solid #ccc;
+  padding: 0.75rem;
+  width: 90%;
+  margin: 1rem auto;
+}


### PR DESCRIPTION
## Summary
- Display previous page names on back buttons and label restart buttons on all pages
- Replace gear icon with settings button, add notice section on top page, and show instructions on settings page
- Update error message, add shared button and info-box styles, and bump version to 1.0.1

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af2f51149c832d931e5cc988ff3f71