### PR TITLE
Add error handling for wage storage

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,7 +58,13 @@ function loadStores() {
 }
 
 function saveStores(stores) {
-  localStorage.setItem('stores', JSON.stringify(stores));
+  try {
+    localStorage.setItem('stores', JSON.stringify(stores));
+    return true;
+  } catch (e) {
+    console.error('saveStores failed', e);
+    return false;
+  }
 }
 
 function getStore(key) {
@@ -69,7 +75,9 @@ function getStore(key) {
 function updateStore(key, values) {
   const stores = loadStores();
   stores[key] = { ...stores[key], ...values };
-  saveStores(stores);
+  if (!saveStores(stores)) {
+    throw new Error('Failed to save stores');
+  }
 }
 
 function startLoading(el, text) {

--- a/settings.js
+++ b/settings.js
@@ -29,13 +29,21 @@ document.addEventListener('DOMContentLoaded', () => {
       alert('数値を入力してください');
       return;
     }
-    updateStore(select.value, {
-      url: document.getElementById('url').value,
-      baseWage,
-      overtime,
-      excludeWords: document.getElementById('excludeWords').value.split(',').map(s => s.trim()).filter(s => s)
-    });
-    alert('保存しました');
+    try {
+      updateStore(select.value, {
+        url: document.getElementById('url').value,
+        baseWage,
+        overtime,
+        excludeWords: document.getElementById('excludeWords').value.split(',').map(s => s.trim()).filter(s => s)
+      });
+      const saved = getStore(select.value);
+      if (saved.baseWage !== baseWage || saved.overtime !== overtime) {
+        throw new Error('verify failed');
+      }
+      alert('保存しました');
+    } catch (e) {
+      alert('保存に失敗しました。ブラウザの設定を確認してください。');
+    }
   });
 
   document.getElementById('reset').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- ensure local wage settings are saved reliably with try/catch and verification
- alert users when saving settings fails

## Testing
- `node --check app.js && echo "app ok" && node --check settings.js && echo "settings ok"`


------
https://chatgpt.com/codex/tasks/task_e_68b080c9e66c832d9a29a55aa7fb954c