### PR TITLE
Improve password gate display

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,9 +10,22 @@ function initPasswordGate() {
   const container = document.createElement('div');
   container.className = 'pw-container';
 
+  const message = document.createElement('div');
+  message.id = 'pw-message';
+  message.className = 'pw-message';
+  message.textContent = 'パスワードを入力してください。';
+  container.appendChild(message);
+
   const display = document.createElement('div');
   display.id = 'pw-display';
   display.className = 'pw-display';
+  const slots = [];
+  for (let i = 0; i < 4; i++) {
+    const span = document.createElement('span');
+    span.className = 'pw-slot';
+    display.appendChild(span);
+    slots.push(span);
+  }
   container.appendChild(display);
 
   const keypad = document.createElement('div');
@@ -42,15 +55,19 @@ function initPasswordGate() {
 
   let input = '';
   function updateDisplay() {
-    display.textContent =
-      (input.split('').join(' ') + ' ' + '＿ '.repeat(4 - input.length)).trim();
+    slots.forEach((s, i) => {
+      s.textContent = input[i] || '';
+    });
   }
   function clearInput(msg) {
-    display.textContent = msg;
-    setTimeout(() => {
-      input = '';
-      updateDisplay();
-    }, 1000);
+    input = '';
+    updateDisplay();
+    if (msg) {
+      message.textContent = msg;
+      setTimeout(() => {
+        message.textContent = 'パスワードを入力してください。';
+      }, 2000);
+    }
   }
   function handleDigit(d) {
     if (input.length >= 4) return;

--- a/style.css
+++ b/style.css
@@ -85,10 +85,24 @@ th, td {
   text-align: center;
 }
 
+#pw-overlay .pw-message {
+  margin-bottom: 0.5rem;
+}
+
 #pw-overlay .pw-display {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
   font-size: 2rem;
-  letter-spacing: 0.5rem;
   margin-bottom: 1rem;
+}
+
+#pw-overlay .pw-slot {
+  display: inline-block;
+  width: 1em;
+  border-bottom: 1px solid #ccc;
+  text-align: center;
+  font-family: monospace;
 }
 
 #pw-overlay .pw-keypad {


### PR DESCRIPTION
## Summary
- Replace shifting underscores with fixed-width slots for stable password input
- Show password instructions and error messages above the slots

## Testing
- ⚠️ `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b41e8d459c832d8327c1617ef10e44