### PR TITLE
Fix password display height for keypad

### DIFF
--- a/style.css
+++ b/style.css
@@ -100,6 +100,8 @@ th, td {
 #pw-overlay .pw-slot {
   display: inline-block;
   width: 1em;
+  height: 1em;
+  line-height: 1em;
   border-bottom: 1px solid #ccc;
   text-align: center;
   font-family: monospace;


### PR DESCRIPTION
## Summary
- keep password slots a constant height to stop the keypad display from jumping when entering digits

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b42bdd49b0832da7799f41606c0452