### PR TITLE
Fix del button alignment in password keypad

### DIFF
--- a/style.css
+++ b/style.css
@@ -115,8 +115,13 @@ th, td {
 }
 
 #pw-overlay .pw-keypad button {
-  padding: 1rem;
+  width: 4rem;
+  height: 4rem;
   font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
 }
 
 #pw-overlay .pw-keypad .pw-empty {


### PR DESCRIPTION
## Summary
- Center del key in password keypad using flexbox sizing to avoid WebKit misalignment

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b47796c988832d93092adf799dcd03