### PR TITLE
feat: refresh remote settings after TTL

### DIFF
--- a/style.css
+++ b/style.css
@@ -87,6 +87,16 @@ th, td {
 
 #pw-overlay .pw-message {
   margin-bottom: 0.5rem;
+  position: relative;
+}
+
+#pw-overlay .pw-loading {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #pw-overlay .pw-display {


### PR DESCRIPTION
## Summary
- add REMOTE_SETTINGS_TTL_MS constant
- store fetchedAt with remote settings and discard expired data
- re-fetch remote settings when TTL expires and update session cache
- show password gate immediately with a loading overlay while settings load
- keep final digit visible briefly before closing password gate

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b76da8c274832d9d752415bd97f775