### PR TITLE
Adjust password query overlay position

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,17 +21,6 @@ function initPasswordGate() {
   message.textContent = 'パスワードを入力してください。';
   container.appendChild(message);
 
-  let loadingCover;
-  if (!settingsLoaded) {
-    loadingCover = document.createElement('div');
-    loadingCover.className = 'pw-loading';
-    loadingCover.textContent = 'パスワード問い合わせ中・・・';
-    message.appendChild(loadingCover);
-    settingsLoadPromise.finally(() => {
-      loadingCover.remove();
-    });
-  }
-
   const display = document.createElement('div');
   display.id = 'pw-display';
   display.className = 'pw-display';
@@ -43,6 +32,16 @@ function initPasswordGate() {
     slots.push(span);
   }
   container.appendChild(display);
+
+  if (!settingsLoaded) {
+    const loadingCover = document.createElement('div');
+    loadingCover.className = 'pw-loading';
+    loadingCover.textContent = 'パスワード問い合わせ中・・・';
+    display.appendChild(loadingCover);
+    settingsLoadPromise.finally(() => {
+      loadingCover.remove();
+    });
+  }
 
   const keypad = document.createElement('div');
   keypad.className = 'pw-keypad';

--- a/style.css
+++ b/style.css
@@ -105,6 +105,7 @@ th, td {
   justify-content: center;
   font-size: 2rem;
   margin-bottom: 1rem;
+  position: relative;
 }
 
 #pw-overlay .pw-slot {


### PR DESCRIPTION
## Summary
- Display password loading indicator over the input field instead of the message
- Ensure password input area can host loading overlay via relative positioning

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b772075e04832da5425c934db710c9