### PR TITLE
Improve password gate mobile usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <title>簡易給与計算</title>
   <link rel="stylesheet" href="style.css">
   <script defer src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>

--- a/payroll.html
+++ b/payroll.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <title>給与計算</title>
   <link rel="stylesheet" href="style.css">
   <script defer src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>

--- a/settings.html
+++ b/settings.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <title>設定</title>
   <link rel="stylesheet" href="style.css">
   <script defer src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>

--- a/sheets.html
+++ b/sheets.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <title>シート選択</title>
   <link rel="stylesheet" href="style.css">
   <script defer src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -97,6 +97,7 @@ th, td {
   display: flex;
   align-items: center;
   justify-content: center;
+  font-size: 1rem;
 }
 
 #pw-overlay .pw-display {
@@ -136,6 +137,7 @@ th, td {
   border-radius: 50%;
   -webkit-border-radius: 50%;
   padding: 0;
+  touch-action: manipulation;
 }
 
 #pw-overlay .pw-keypad .pw-empty {


### PR DESCRIPTION
## Summary
- keep "パスワード問い合わせ中" loading text at normal body size
- disable mobile zoom by setting `user-scalable=no`
- prevent double-tap zoom on keypad buttons with `touch-action: manipulation`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ade2cd2c832da58bbf3372220943