### PR TITLE
Add Jest tests for payroll calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/__tests__/calc.test.js
+++ b/__tests__/calc.test.js
@@ -1,0 +1,35 @@
+const { calculateEmployee, calculatePayroll } = require('../calc');
+
+describe('calculateEmployee', () => {
+  test('computes hours, days, and salary including overtime', () => {
+    const schedule = ['9-17', '9-18', '9-19'];
+    const baseWage = 1000;
+    const overtime = 1.25;
+    const result = calculateEmployee(schedule, baseWage, overtime);
+    expect(result).toEqual({ hours: 24, days: 3, salary: 24250 });
+  });
+});
+
+describe('calculatePayroll', () => {
+  test('aggregates payroll for multiple employees', () => {
+    const data = Array.from({ length: 34 }, () => []);
+    // Header row with employee names starting from column index 3
+    data[2][3] = 'Alice';
+    data[2][4] = 'Bob';
+    // Alice schedules
+    data[3][3] = '9-17'; // 8h -> 7h after deduction
+    data[4][3] = '10-15'; // 5h
+    // Bob schedules
+    data[3][4] = '9-19'; // 10h -> 9h after deduction
+
+    const baseWage = 1000;
+    const overtime = 1.25;
+    const { results, totalSalary } = calculatePayroll(data, baseWage, overtime);
+
+    expect(results).toEqual([
+      { name: 'Alice', baseWage, hours: 12, days: 2, salary: 12000 },
+      { name: 'Bob', baseWage, hours: 9, days: 1, salary: 9250 }
+    ]);
+    expect(totalSalary).toBe(21250);
+  });
+});

--- a/calc.js
+++ b/calc.js
@@ -1,0 +1,77 @@
+const TIME_RANGE_REGEX = /^(\d{1,2})(?::(\d{2}))?-(\d{1,2})(?::(\d{2}))?$/;
+const BREAK_DEDUCTIONS = [
+  { minHours: 8, deduct: 1 },
+  { minHours: 7, deduct: 0.75 },
+  { minHours: 6, deduct: 0.5 }
+];
+
+function calculateEmployee(schedule, baseWage, overtime) {
+  let total = 0;
+  let workdays = 0;
+  let salary = 0;
+  schedule.forEach(cell => {
+    if (!cell) return;
+    const segments = cell.toString().split(',');
+    let dayHours = 0;
+    let hasValid = false;
+    segments.forEach(seg => {
+      const m = seg.trim().match(TIME_RANGE_REGEX);
+      if (!m) return;
+      const sh = parseInt(m[1], 10);
+      const sm = m[2] ? parseInt(m[2], 10) : 0;
+      const eh = parseInt(m[3], 10);
+      const em = m[4] ? parseInt(m[4], 10) : 0;
+      if (
+        sh < 0 || sh > 24 || eh < 0 || eh > 24 ||
+        sm < 0 || sm >= 60 || em < 0 || em >= 60
+      ) return;
+      hasValid = true;
+      const start = sh * 60 + sm;
+      const end = eh * 60 + em;
+      const diff = end >= start ? end - start : 24 * 60 - start + end;
+      dayHours += diff / 60;
+    });
+    if (!hasValid || dayHours <= 0) return;
+    workdays++;
+    for (const rule of BREAK_DEDUCTIONS) {
+      if (dayHours >= rule.minHours) {
+        dayHours -= rule.deduct;
+        break;
+      }
+    }
+    total += dayHours;
+    const regular = Math.min(dayHours, 8);
+    const over = Math.max(dayHours - 8, 0);
+    salary += regular * baseWage + over * baseWage * overtime;
+  });
+  return { hours: total, days: workdays, salary: Math.floor(salary) };
+}
+
+function calculatePayroll(data, baseWage, overtime, excludeWords = []) {
+  const header = data[2];
+  const names = [];
+  const schedules = [];
+  for (let col = 3; col < header.length; col++) {
+    const name = header[col];
+    if (name && !excludeWords.some(word => name.includes(word))) {
+      names.push(name);
+      // rows 4-34 contain daily schedules
+      schedules.push(data.slice(3, 34).map(row => row[col]));
+    }
+  }
+
+  const results = names.map((name, idx) => {
+    const r = calculateEmployee(schedules[idx], baseWage, overtime);
+    return { name, baseWage, hours: r.hours, days: r.days, salary: r.salary };
+    });
+
+  const totalSalary = results.reduce((sum, r) => sum + r.salary, 0);
+  return { results, totalSalary, schedules };
+}
+
+module.exports = {
+  calculateEmployee,
+  calculatePayroll,
+  TIME_RANGE_REGEX,
+  BREAK_DEDUCTIONS
+};

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
   "name": "yo_payroll_web_app",
   "version": "1.4.1",
-
   "description": "",
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add payroll calculation helper module with `calculateEmployee` and `calculatePayroll`
- configure Jest for automated testing
- introduce test cases for employee and payroll computations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c9812964832d85f1f91a611a5467