### PR TITLE
Add UTF-8 BOM for text downloads

### DIFF
--- a/payroll.js
+++ b/payroll.js
@@ -168,7 +168,8 @@ function setupDownload(storeName, period, results) {
 }
 
 function downloadBlob(content, fileName, mimeType) {
-  const blob = new Blob([content], { type: mimeType });
+  const bom = new Uint8Array([0xEF, 0xBB, 0xBF]);
+  const blob = new Blob([bom, content], { type: `${mimeType};charset=utf-8` });
   const a = document.createElement('a');
   a.href = URL.createObjectURL(blob);
   a.download = fileName;


### PR DESCRIPTION
## Summary
- ensure downloaded CSV and TXT files include a UTF-8 BOM to avoid mojibake

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b827166d74832d9f625e6377a54986