### PR TITLE
Improve PDF export to use selectable text

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "jspdf": "^2.5.1"
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.5.28"
   },
   "devDependencies": {
     "jest": "^29.7.0"


### PR DESCRIPTION
## Summary
- generate PDF with jsPDF autoTable instead of rasterized canvas
- embed Japanese font for selectable text in exports
- add jspdf-autotable dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8bb620b98832da7edfb130ee61363