### PR TITLE
Always refetch remote settings on reload

### DIFF
--- a/app.js
+++ b/app.js
@@ -321,15 +321,20 @@ function saveSettingsToSession() {
 }
 
 function ensureSettingsLoaded() {
-  if (loadSettingsFromSession()) {
-    return Promise.resolve();
-  }
+  // Always attempt to load previously fetched settings so that we have a
+  // usable configuration even if the network request fails. However, to make
+  // sure the latest settings are applied on every reload, we do not return
+  // early based on the cached data and instead always fetch the remote
+  // settings.
+  loadSettingsFromSession();
   if (!settingsLoadPromise) {
-    settingsLoadPromise = fetchRemoteSettings().then(() => {
-      saveSettingsToSession();
-    }).finally(() => {
-      settingsLoadPromise = null;
-    });
+    settingsLoadPromise = fetchRemoteSettings()
+      .then(() => {
+        saveSettingsToSession();
+      })
+      .finally(() => {
+        settingsLoadPromise = null;
+      });
   }
   return settingsLoadPromise;
 }


### PR DESCRIPTION
## Summary
- Always load cached settings but always fetch remote settings to ensure overwriting on reload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94919900c832d95b147dba75d60fc